### PR TITLE
Improve error handling.

### DIFF
--- a/src/main/kotlin/io/thecontext/ci/Main.kt
+++ b/src/main/kotlin/io/thecontext/ci/Main.kt
@@ -5,6 +5,16 @@ import java.io.File
 
 fun main(args: Array<String>) {
     val arguments = Arguments.from(args)
+    val runner = Runner.Impl(Context.Impl())
 
-    Runner(Context.Impl(), File(arguments.inputPath), File(arguments.outputFeedPath), File(arguments.outputWebsitePath)).run()
+    val inputDirectory = File(arguments.inputPath)
+    val outputFeedFile = File(arguments.outputFeedPath)
+    val outputWebsiteDirectory = File(arguments.outputWebsitePath)
+
+    val result = runner.run(inputDirectory, outputFeedFile, outputWebsiteDirectory).blockingGet()
+
+    when (result) {
+        is Runner.Result.Success -> println(":: Success!")
+        is Runner.Result.Failure -> listOf(":: Failure.", result.message).forEach { println(it) }
+    }
 }

--- a/src/main/kotlin/io/thecontext/ci/Main.kt
+++ b/src/main/kotlin/io/thecontext/ci/Main.kt
@@ -3,6 +3,11 @@ package io.thecontext.ci
 import io.thecontext.ci.context.Context
 import java.io.File
 
+enum class ResultCode(val value: Int) {
+    Success(0),
+    Failure(1),
+}
+
 fun main(args: Array<String>) {
     val arguments = Arguments.from(args)
     val runner = Runner.Impl(Context.Impl())
@@ -13,8 +18,20 @@ fun main(args: Array<String>) {
 
     val result = runner.run(inputDirectory, outputFeedFile, outputWebsiteDirectory).blockingGet()
 
-    when (result) {
-        is Runner.Result.Success -> println(":: Success!")
-        is Runner.Result.Failure -> listOf(":: Failure.", result.message).forEach { println(it) }
+    val resultCode = when (result) {
+        is Runner.Result.Success -> {
+            println(":: Success!")
+
+            ResultCode.Success
+        }
+
+        is Runner.Result.Failure -> {
+            println(":: Failure.")
+            println(result.message)
+
+            ResultCode.Failure
+        }
     }
+
+    System.exit(resultCode.value)
 }

--- a/src/main/kotlin/io/thecontext/ci/Reactive.kt
+++ b/src/main/kotlin/io/thecontext/ci/Reactive.kt
@@ -1,9 +1,0 @@
-package io.thecontext.ci
-
-import io.reactivex.Observable
-import io.reactivex.functions.BiFunction
-
-inline fun <reified R : Any> Observable<*>.ofType(): Observable<R> = ofType(R::class.java)
-
-inline fun <T1, T2, R> Observable<T1>.withLatestFrom(observable: Observable<T2>, crossinline predicate: (T1, T2) -> R): Observable<R> =
-        withLatestFrom(observable, BiFunction { t1, t2 -> predicate.invoke(t1, t2) })

--- a/src/main/kotlin/io/thecontext/ci/context/Context.kt
+++ b/src/main/kotlin/io/thecontext/ci/context/Context.kt
@@ -7,13 +7,11 @@ import io.thecontext.ci.Time
 interface Context {
 
     val ioScheduler: Scheduler
-
     val time: Time
 
     class Impl : Context {
 
         override val ioScheduler by lazy { Schedulers.io() }
-
         override val time: Time by lazy { Time.Impl() }
     }
 }

--- a/src/main/kotlin/io/thecontext/ci/input/InputFilesLocator.kt
+++ b/src/main/kotlin/io/thecontext/ci/input/InputFilesLocator.kt
@@ -26,6 +26,10 @@ interface InputFilesLocator {
 
         override fun locate(directory: File) = Single
                 .fromCallable {
+                    if (!directory.exists()) {
+                        return@fromCallable Result.Failure("Podcast directory does not exist.")
+                    }
+
                     if (!directory.isDirectory) {
                         return@fromCallable Result.Failure("Podcast directory [${directory.path}] is not actually a directory.")
                     }

--- a/src/test/kotlin/io/thecontext/ci/IntegrationSpec.kt
+++ b/src/test/kotlin/io/thecontext/ci/IntegrationSpec.kt
@@ -3,7 +3,6 @@ package io.thecontext.ci
 import com.greghaskins.spectrum.Spectrum
 import com.greghaskins.spectrum.dsl.specification.Specification.*
 import io.thecontext.ci.context.Context
-import io.thecontext.ci.output.OutputWriter
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
@@ -34,12 +33,7 @@ class IntegrationSpec {
                     }
                 }
 
-                Runner(
-                        context = context,
-                        inputDirectory = inputDir,
-                        outputFeedFile = File(actualOutputDir, actualFeedFileName),
-                        outputWebsiteDirectory = actualOutputDir
-                ).run()
+                Runner.Impl(context).run(inputDir, File(actualOutputDir, actualFeedFileName), actualOutputDir).blockingGet()
             }
 
             it("creates RSS feed") {

--- a/src/test/kotlin/io/thecontext/ci/input/InputFilesLocatorSpec.kt
+++ b/src/test/kotlin/io/thecontext/ci/input/InputFilesLocatorSpec.kt
@@ -21,16 +21,29 @@ class InputFilesLocatorSpec {
             workingDir.create()
         }
 
-        describe("directory is not a directory") {
+        describe("directory does not exist") {
 
             it("emits result as failure") {
-                locator.locate(File(workingDir.root, "just-a-file"))
+                val dir = File("does-not-actually-exist")
+
+                locator.locate(dir)
                         .test()
                         .assertValue { it is Result.Failure }
             }
         }
 
-        describe("no people file available") {
+        describe("directory is not a directory") {
+
+            it("emits result as failure") {
+                val file = workingDir.newFile("podcast")
+
+                locator.locate(file)
+                        .test()
+                        .assertValue { it is Result.Failure }
+            }
+        }
+
+        describe("people file is not available") {
 
             beforeEach {
                 workingDir.newFile(FileNames.PODCAST)
@@ -49,7 +62,7 @@ class InputFilesLocatorSpec {
             }
         }
 
-        describe("no podcast file available") {
+        describe("podcast file is not available") {
 
             beforeEach {
                 workingDir.newFile(FileNames.PEOPLE)
@@ -68,7 +81,7 @@ class InputFilesLocatorSpec {
             }
         }
 
-        describe("no episode file available") {
+        describe("episode file is not available") {
 
             beforeEach {
                 listOf(FileNames.PEOPLE, FileNames.PODCAST).forEach {
@@ -86,7 +99,7 @@ class InputFilesLocatorSpec {
             }
         }
 
-        describe("no episode notes file available") {
+        describe("episode notes file is not available") {
 
             beforeEach {
                 listOf(FileNames.PEOPLE, FileNames.PODCAST).forEach {


### PR DESCRIPTION
Hopefully closes #48.

* Makes error handling in `Runner` much more explicit and reliable.
* Printing results moved from `Runner` to `Main`.
* YAML deserialisation errors will no longer result in stacktraces but in a semi-helpful messages with a bad file mentioning and missing property names.